### PR TITLE
Setting node environment to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "tsc": "tsc --p ./src/tsconfig.json 2>&1 || true && echo Please ignore tsc errors for now!",
-    "build": "npm run build:babel && npm run build:webpack && npm run tsc",
+    "build": "SET NODE_ENV=production && npm run build:babel && npm run build:webpack && npm run tsc",
     "build:babel": "babel src/ --copy-files --extensions .js,.ts,.tsx --no-copy-ignored --out-dir lib/ --verbose",
     "build:webpack": "webpack",
     "prestart": "npm run build:babel",


### PR DESCRIPTION
**Issue**
Current npm pack is outputs a chat-adapter.js in developement mode. The resultant file size 1.2 MB. 

**Fix**
Setting node environment to production. With this change the file size comes down to 160 KB.