### PR TITLE
Setting node environment to production

### DIFF
--- a/.github/workflows/ersuo_test_node.js.yml
+++ b/.github/workflows/ersuo_test_node.js.yml
@@ -18,8 +18,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      NODE_ENV: production
 
     strategy:
       matrix:
@@ -40,6 +38,8 @@ jobs:
       - run: npm ci
 
       - run: npm run build --if-present
+        env:
+          NODE_ENV: production
 
       - run: node_modules/.bin/jest
 

--- a/.github/workflows/ersuo_test_node.js.yml
+++ b/.github/workflows/ersuo_test_node.js.yml
@@ -18,6 +18,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
 
     strategy:
       matrix:


### PR DESCRIPTION
**Issue**
Chat-adapter is currently building in developement mode and outputting 1.2 MB file.

**Fix**
Setting node environment to production. With this change the library size will be reduced to 160 KB.